### PR TITLE
Change GitHub workflows relating to Javadoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Build Javadoc
+      run: ./gradlew javadoc
     - name: Upload JAR as an artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,11 +1,11 @@
 # This workflow creates the javadoc and publishes it to GitHub Pages
 
-name: Generate Javadoc
+name: Generate Javadoc and publish to gh-pages
 
 on: 
-  push:
-    branches:
-     - main
+  release:
+    types: [published,edited,created]
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
This makes the Javadoc only generate and publish every new release. The normal CI will also check if the Javadoc builds successfully. 