### PR TITLE
Version 1.2.0 - Overhaul message reach configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See more examples on the [Wiki](https://diademiemi.github.io/Lineation/wiki/inde
 - `/lineation line <name> option removecommand <number>` - Removes a command by number  
 - `/lineation line <name> option laps <number>` - Amount of times players have to go through the course before winning  
   (This requires at least one checkpoint to be set, place them appropriately around your course)  
-- `/lineation line <name> option messagereach <all/world/disabled>` - Sets who the announcement messages will target  
+- `/lineation line <name> option messagereach <all/area/world/number/disabled>` - Sets if messages will target all players, players in the area, players in the world, players a certain distance from the center of the area or send no messages.
 - `/ineation line <name> option gamemodes <survival,adventure>` - Comma seperated list of gamemodes players have to be in to be counted  
 - `/lineation line <name> option illegalarea add` - Adds an area that will teleport players to the start line if teleport illegalarea is set to true  
 - `/lineation line <name> option illegalarea remove <number/all>` - Removes an illegal area  

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'me.diademiemi.lineation'
-version '1.1.1'
+version '1.2.0'
 
 repositories {
   /*

--- a/src/main/java/me/diademiemi/lineation/command/CommandExec.java
+++ b/src/main/java/me/diademiemi/lineation/command/CommandExec.java
@@ -369,6 +369,7 @@ public class CommandExec implements CommandExecutor {
 																		}
 																	} else sender.sendMessage(Message.ERROR_NO_PERMS);
 																} else sender.sendMessage(Message.ERROR_SEE_HELP.replace("$COMMAND$", "/lineation help options"));
+																break;
                                                             case "gamemodes":
                                                                 if (args.length > 4) {
                                                                     if (sender.hasPermission("lineation.line.option.gamemodes")) {

--- a/src/main/java/me/diademiemi/lineation/command/CommandExec.java
+++ b/src/main/java/me/diademiemi/lineation/command/CommandExec.java
@@ -348,23 +348,27 @@ public class CommandExec implements CommandExecutor {
                                                                 break;
                                                             case "messagereach":
                                                                 if (args.length > 4) {
-                                                                    switch (args[4].toLowerCase()) {
-                                                                        case "world":
-                                                                        case "disabled":
-                                                                        case "all":
-                                                                            if (sender.hasPermission("lineation.line.option.messagereach")) {
-                                                                                if (line.getType().equalsIgnoreCase("finish")) {
-                                                                                    line.setMessageReach(args[4]);
-                                                                                    sender.sendMessage(Message.SUCCESS_OPTION_SET);
-                                                                                } else sender.sendMessage(Message.ERROR_NOT_FINISH.replace("$LINE$", args[1]));
-                                                                            } else sender.sendMessage(Message.ERROR_NO_PERMS);
-                                                                            break;
-                                                                        default:
-                                                                            sender.sendMessage(Message.ERROR_UNKNOWN_ARGS);
-                                                                    }
-                                                                    break;
-                                                                } else sender.sendMessage(Message.ERROR_SEE_HELP.replace("$COMMAND$", "/lineation help options"));
-                                                                break;
+																	if (sender.hasPermission("lineation.line.option.messagereach")) {
+																		switch (args[4].toLowerCase()) {
+																			case "disabled":
+																			case "world":
+																			case "area":
+																			case "all":
+																					line.setMessageReach(args[4]);
+																					sender.sendMessage(Message.SUCCESS_OPTION_SET);
+																				break;
+																			default:
+																				try {
+																					Integer.parseInt(args[4]);
+																					line.setMessageReach(args[4]);
+																					sender.sendMessage(Message.SUCCESS_OPTION_SET);
+																				} catch (Exception e) {
+																					sender.sendMessage(Message.ERROR_UNKNOWN_ARGS);
+																				}
+																				break;
+																		}
+																	} else sender.sendMessage(Message.ERROR_NO_PERMS);
+																} else sender.sendMessage(Message.ERROR_SEE_HELP.replace("$COMMAND$", "/lineation help options"));
                                                             case "gamemodes":
                                                                 if (args.length > 4) {
                                                                     if (sender.hasPermission("lineation.line.option.gamemodes")) {

--- a/src/main/java/me/diademiemi/lineation/command/CommandTabComplete.java
+++ b/src/main/java/me/diademiemi/lineation/command/CommandTabComplete.java
@@ -201,7 +201,7 @@ public class CommandTabComplete implements TabCompleter {
 
                         if (args[3].equalsIgnoreCase("")) {
 
-                            if (player.hasPermission("lineation.line.option.messagereach") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("messagereach");
+                            if (player.hasPermission("lineation.line.option.messagereach")) tabList.add("messagereach");
                             if (player.hasPermission("lineation.line.option.maxwinners") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("maxwinners");
                             if (player.hasPermission("lineation.line.option.addcommand") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("addcommand");
                             if (player.hasPermission("lineation.line.option.removecommand") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("removecommand");
@@ -213,7 +213,7 @@ public class CommandTabComplete implements TabCompleter {
                             
                         }
 
-                        if ("messagereach".startsWith(args[3]) && player.hasPermission("lineation.line.option.messagereach") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("messagereach");
+                        if ("messagereach".startsWith(args[3]) && player.hasPermission("lineation.line.option.messagereach")) tabList.add("messagereach");
                         if ("maxwins".startsWith(args[3]) && player.hasPermission("lineation.line.option.maxwinners") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("maxwinners");
                         if ("addcommand".startsWith(args[3]) && player.hasPermission("lineation.line.option.addcommand") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("addcommand");
                         if ("removecommand".startsWith(args[3]) && player.hasPermission("lineation.line.option.removecommand") && Line.getLines().get(args[1]).getType().equalsIgnoreCase("finish")) tabList.add("removecommand");
@@ -278,7 +278,24 @@ public class CommandTabComplete implements TabCompleter {
                     
                     if (args[2].equalsIgnoreCase("option")) {
 
-                        if (args[3].equalsIgnoreCase("teleport") && player.hasPermission("lineation.line.option.teleport")) {
+						if (args[3].equalsIgnoreCase("messagereach") && player.hasPermission("lineation.line.option.messagereach")) {
+
+							if (args[4].equalsIgnoreCase("")) {
+
+								tabList.add("area");
+								tabList.add("all");
+								tabList.add("world");
+								tabList.add("100");
+								tabList.add("disabled");
+
+							}
+
+							if ("area".startsWith(args[4])) tabList.add("area");
+							if ("all".startsWith(args[4])) tabList.add("all");
+							if ("world".startsWith(args[4])) tabList.add("world");
+							if ("disabled".startsWith(args[4])) tabList.add("disabled");
+
+						} else if (args[3].equalsIgnoreCase("teleport") && player.hasPermission("lineation.line.option.teleport")) {
 
                             if (args[4].equalsIgnoreCase("")) {
 								

--- a/src/main/java/me/diademiemi/lineation/line/LineTools.java
+++ b/src/main/java/me/diademiemi/lineation/line/LineTools.java
@@ -273,6 +273,7 @@ public class LineTools {
 						.replace("$TPONSTART$", Boolean.toString(line.isTeleportEnabled()))
 						.replace("$TPILLEGALAREA$", Boolean.toString(line.isTeleportEnabledIllegalArea()))
                         .replace("$TELEPORTLOCATION$", teleportLocation)
+                        .replace("$MESSAGEREACH$", line.getMessageReach())
 						.replace("$GAMEMODES$", line.getGameModesString())
 						.replace("$ILLEGALAREAS$", illegalAreasString)
                         .replace("$LINKED$", line.getLinkedLine()));

--- a/src/main/java/me/diademiemi/lineation/line/LineTools.java
+++ b/src/main/java/me/diademiemi/lineation/line/LineTools.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.command.CommandSender;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.Location;
 import org.bukkit.World;
 
 import me.diademiemi.lineation.Lineation;
@@ -76,6 +77,52 @@ public class LineTools {
 
         }
     }
+
+	/**
+	 * Get a list of players that a message should be sent to according to the lines messagereach option
+	 *
+	 * @param line	Line to get message reach from
+	 *
+	 * @return	List of players
+	 */
+	public static List<Player> getMessagePlayers(Line line) {
+		List<Player> players;
+		switch (line.getMessageReach()) {
+			case "all":
+				players = new ArrayList<>(Bukkit.getOnlinePlayers());
+				break;
+            case "world":
+                players = line.getWorld().getPlayers();
+				break;
+			case "area":
+				players = line.getPlayers();
+				break;
+			case "disabled":
+				players = new ArrayList<>();
+				break;
+			default:
+				try {
+					int i = Integer.parseInt(line.getMessageReach());
+					double[][] a = line.getArea();
+					double[] areaCenter = new double[2];
+					areaCenter[0] = a[0][0] / a[1][0];
+					areaCenter[1] = a[0][1] / a[1][1];
+					areaCenter[2] = a[0][2] / a[1][2];
+					Location centerLocation = new Location(line.getWorld(), areaCenter[0], areaCenter[1], areaCenter[2]);
+					players = line.getWorld().getPlayers();
+					for (Player p : players) {
+						if (centerLocation.distance(p.getLocation()) > i) {
+							players.remove(p);
+						}
+					}
+				} catch (Exception e) {
+					players = new ArrayList<>();
+				}
+				break;
+		}
+		return players;
+	}
+	
   
     /**
      * Send finish message when someone finishes
@@ -85,21 +132,11 @@ public class LineTools {
      * @param place Place number player got
      */
     public static void finishMessage(Line line, Player player, Integer place) {
-        switch (line.getMessageReach()) {
-            case "world":
-                List<Player> players = line.getWorld().getPlayers();
-                for (Player p : players) {
-                    p.sendMessage(Message.PLAYER_FINISHED
-                            .replace("$NAME$", player.getName())
-                            .replace("$PLACE$", Message.ordinal(place)));
-                }
-                break;
-            case "all":
-                Bukkit.broadcastMessage(Message.PLAYER_FINISHED
-                        .replace("$NAME$", player.getName())
-                        .replace("$PLACE$", Message.ordinal(place)));
-                break;
-        }
+		for (Player p : getMessagePlayers(line)) {
+			p.sendMessage(Message.PLAYER_FINISHED
+					.replace("$NAME$", player.getName())
+					.replace("$PLACE$", Message.ordinal(place)));
+		}
     }
    
     /**
@@ -110,21 +147,11 @@ public class LineTools {
      * @param i Number of the lap
      */
     public static void lapMessage(Line line, Player player, Integer i) {
-        switch (line.getMessageReach()) {
-            case "world":
-                List<Player> players = line.getWorld().getPlayers();
-                for (Player p : players) {
-                    p.sendMessage(Message.PLAYER_LAP
-                            .replace("$NAME$", player.getName())
-                            .replace("$LAP$", i + "/" + line.getLaps()));
-                }
-                break;
-            case "all":
-                Bukkit.broadcastMessage(Message.PLAYER_LAP
-                        .replace("$NAME$", player.getName())
-                        .replace("$LAP$", i + "/" + line.getLaps()));
-                break;
-        }
+		for (Player p : getMessagePlayers(line)) {
+			p.sendMessage(Message.PLAYER_LAP
+					.replace("$NAME$", player.getName())
+					.replace("$LAP$", i + "/" + line.getLaps()));
+		}
     }
 
     /**
@@ -147,17 +174,9 @@ public class LineTools {
             i++;
         }
 
-        switch (line.getMessageReach()) {
-            case "world":
-                List<Player> players = line.getWorld().getPlayers();
-                for (Player p : players) {
-                    p.sendMessage(announcement.toString());
-                }
-                break;
-            case "all":
-                Bukkit.broadcastMessage(announcement.toString());
-                break;
-        }
+		for (Player p : getMessagePlayers(line)) {
+			p.sendMessage(announcement.toString());
+		}
     }
                     
 
@@ -530,15 +549,15 @@ public class LineTools {
                             replaceBlocks(es, b, line.getWorld(), "air", blockSequence.get(i - 1));
                         }
 
-                        for (Player p : players) {
+                        for (Player p : getMessagePlayers(line)) {
                             p.sendMessage(Message.STARTING_NOW);
                         }
 
                         if (line.isTeleportEnabled()) {
                             for (Player p : players) {
-				if(line.getGameModes().contains(p.getGameMode())) {
+								if(line.getGameModes().contains(p.getGameMode())) {
                                     p.teleport(line.getTeleportLocation());
-				}
+								}
                             }
                         }
 
@@ -548,7 +567,7 @@ public class LineTools {
                             replaceBlocks(es, b, line.getWorld(), blockSequence.get(i), blockSequence.get(i - 1));
                         }
 
-                        for (Player p : players) {
+                        for (Player p : getMessagePlayers(line)) {
                             p.sendMessage(Message.STARTING_IN.replace("$SECONDS$", String.valueOf(blockSequence.size() - i)));
                         }
 

--- a/src/main/java/me/diademiemi/lineation/line/LineTools.java
+++ b/src/main/java/me/diademiemi/lineation/line/LineTools.java
@@ -104,15 +104,15 @@ public class LineTools {
 				try {
 					int i = Integer.parseInt(line.getMessageReach());
 					double[][] a = line.getArea();
-					double[] areaCenter = new double[2];
-					areaCenter[0] = a[0][0] / a[1][0];
-					areaCenter[1] = a[0][1] / a[1][1];
-					areaCenter[2] = a[0][2] / a[1][2];
+					double[] areaCenter = new double[3];
+					areaCenter[0] = (a[0][0] + a[1][0]) / 2.0;
+					areaCenter[1] = (a[0][1] + a[1][1]) / 2.0;
+					areaCenter[2] = (a[0][2] + a[1][2]) / 2.0;
 					Location centerLocation = new Location(line.getWorld(), areaCenter[0], areaCenter[1], areaCenter[2]);
-					players = line.getWorld().getPlayers();
-					for (Player p : players) {
-						if (centerLocation.distance(p.getLocation()) > i) {
-							players.remove(p);
+					players = new ArrayList<>();
+					for (Player p : line.getWorld().getPlayers()) {
+						if (centerLocation.distance(p.getLocation()) < (double)i) {
+							players.add(p);
 						}
 					}
 				} catch (Exception e) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,8 +6,8 @@
 # Players wins can be wiped with /lineation config forget USERNAME
 linedefaults:
   option:
-    blocksequence: glass,red_stained_glass,yellow_stained_glass,lime_stained_glass
-    messagereach: world
+    blocksequence: glass, red_stained_glass, yellow_stained_glass, lime_stained_glass
+    messagereach: '250'
     maxwinners: 3
     commands: []
     gamemodes: SURVIVAL,ADVENTURE

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -34,7 +34,7 @@ HELP_OPTION: |2-
   &7/lineation line <name> option addcommand <command> &r: Sets a command to run when a player finishes. Placeholders: %player%, %uuid%
   &7/lineation line <name> option removecommand <number> &r: Removes a command by number
   &7/lineation line <name> option laps <number> &r: Amount of times players have to go through the course before winning
-  &7/lineation line <name> option messagereach <all/world/disabled> &r: Sets who the announcement messages will target
+  &7/lineation line <name> option messagereach <all/area/world/number/disabled> &r: Sets if messages will target all players, players in the area, players in the world, players a certain distance from the center of the area or send no messages.
   &7/lineation line <name> option gamemodes <survival,adventure> &r: Comma or space seperated list of gamemodes players have to be in to be counted
   &7/lineation line <name> option illegalarea add &r: Adds an area that will teleport players to the start line if teleport illegalarea is set to true 
   &7/lineation line <name> option illegalarea remove <number/all>&r: Removes an illegal area 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -93,6 +93,7 @@ LINE_OPTIONS_START: |2-
   &8- &7Teleport onstart: $TPONSTART$
   &8- &7Teleport illegalarea: $TPILLEGALAREA$
   &8- &7Teleport location: $TELEPORTLOCATION$
+  &8- &7Message reach: $MESSAGEREACH$
   &8- &7Illegal Area gamemodes: $GAMEMODES$
   &8- &7Illegal Areas: $ILLEGALAREAS$
   &8- &7Linked line: $LINKED$

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Lineation
 description:  Minecraft Spigot plugin for managing start and finish lines
 author: diademiemi
-version: 1.1.1
+version: 1.2.0
 main: me.diademiemi.lineation.Lineation
 api-version: 1.16
 depend: [WorldEdit]


### PR DESCRIPTION
This release adds new features to the messagereach option, it now is able to target players by range from the center of the lines area.
The new options are:
`all` - Target all players  
`area` - Target players in the area (Not recommended for finish lines, will only announce results to players who have finished)  
`world` - Target all players in the lines world  
`disabled` - Disable announcement messages (Countdown, go, player finishes, results)  
You can also enter a number, this will then send the messages to all players that are within this distance of the center of the lines area.  